### PR TITLE
[ Feature ] - proma_backend 채팅창 관련 api 

### DIFF
--- a/proma/src/main/java/ai/platform/proma/controller/ChatRoomController.java
+++ b/proma/src/main/java/ai/platform/proma/controller/ChatRoomController.java
@@ -1,0 +1,28 @@
+package ai.platform.proma.controller;
+
+import ai.platform.proma.dto.request.ListPromptAtom;
+import ai.platform.proma.dto.response.MessageListResponseDto;
+import ai.platform.proma.dto.response.ResponseDto;
+import ai.platform.proma.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chatting")
+public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/room/{chatRoomId}")
+    public ResponseDto<Map<String, List<MessageListResponseDto>>> enterChatRoom(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @RequestParam("userId") Long userId
+    ) {
+        return new ResponseDto<>(chatRoomService.enterChatRoom(chatRoomId, userId));
+    }
+
+
+}

--- a/proma/src/main/java/ai/platform/proma/controller/ChatRoomController.java
+++ b/proma/src/main/java/ai/platform/proma/controller/ChatRoomController.java
@@ -24,5 +24,12 @@ public class ChatRoomController {
         return new ResponseDto<>(chatRoomService.enterChatRoom(chatRoomId, userId));
     }
 
-
+    @PatchMapping("prompt/block/{promptId}")
+    public ResponseDto<Boolean> blockPrompt(
+            @PathVariable("promptId") Long promptId,
+            @RequestParam("userId") Long userId,
+            @RequestBody List<ListPromptAtom> listPromptAtoms
+            ) {
+        return new ResponseDto<>(chatRoomService.updatePromptBlock(listPromptAtoms, promptId, userId));
+    }
 }

--- a/proma/src/main/java/ai/platform/proma/controller/ChatRoomSidebarController.java
+++ b/proma/src/main/java/ai/platform/proma/controller/ChatRoomSidebarController.java
@@ -52,7 +52,7 @@ public class ChatRoomSidebarController {
         return new ResponseDto<>(chatRoomSidebarService.deleteChatRoom(chatRoomId, userId));
     }
 
-    @PatchMapping("/sidebar/prompt/{promptId}")
+    @PatchMapping("/prompt/{promptId}")
     public ResponseDto<Boolean> updatePromptDetail(
             @RequestBody PromptDetailUpdateRequestDto promptDetailUpdateRequestDto,
             @RequestParam("promptId") Long promptId
@@ -60,7 +60,7 @@ public class ChatRoomSidebarController {
         return new ResponseDto<>(chatRoomSidebarService.updatePromptDetail(promptDetailUpdateRequestDto, promptId));
     }
 
-    @DeleteMapping("/sidebar/prompt/{promptId}")
+    @DeleteMapping("/prompt/{promptId}")
     public ResponseDto<Boolean> deletePrompt(
             @PathVariable("promptId") Long promptId,
             @RequestParam("userId") Long userId
@@ -68,7 +68,7 @@ public class ChatRoomSidebarController {
         return new ResponseDto<>(chatRoomSidebarService.deletePrompt(promptId, userId));
     }
 
-    @GetMapping("/sidebar/prompt/list")
+    @GetMapping("/prompt/list")
     public ResponseDto<Map<String, List<PromptListResponseDto>>> promptList(
             @RequestParam("userId") Long userId
     ) {

--- a/proma/src/main/java/ai/platform/proma/dto/response/MessageListResponseDto.java
+++ b/proma/src/main/java/ai/platform/proma/dto/response/MessageListResponseDto.java
@@ -1,0 +1,43 @@
+package ai.platform.proma.dto.response;
+
+import ai.platform.proma.domain.ChatRoom;
+import ai.platform.proma.domain.Message;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class MessageListResponseDto {
+    private Long messageId;
+    private Long promptId;
+    private Long chatRoomId;
+    private String messageQuestion;
+    private String messageAnswer;
+    private LocalDate messageCreateAt;
+    private String messageFile;
+
+
+    @Builder
+    public MessageListResponseDto(Message message, ChatRoom chatRoom){
+        this.messageId = message.getId();
+        this.promptId = message.getPrompt().getId();
+        this.chatRoomId = chatRoom.getId();
+        this.messageQuestion = message.getMessageQuestion();
+        this.messageAnswer = message.getMessageAnswer();
+        this.messageCreateAt = message.getMessageCreateAt();
+        this.messageFile = message.getMessageFile();
+    }
+
+    public static MessageListResponseDto of(Message message, ChatRoom chatRoom){
+        return MessageListResponseDto.builder()
+                .message(message)
+                .chatRoom(chatRoom)
+                .build();
+    }
+
+
+
+}

--- a/proma/src/main/java/ai/platform/proma/exception/ErrorDefine.java
+++ b/proma/src/main/java/ai/platform/proma/exception/ErrorDefine.java
@@ -18,6 +18,8 @@ public enum ErrorDefine {
     PROMPT_NOT_FOUND("4043", HttpStatus.NOT_FOUND, "Not Found: Prompt Not Found"),
     CHAT_ROOM_NOT_FOUND("4044", HttpStatus.NOT_FOUND, "Not Found: Chat Room Not Found"),
     BLOCK_NOT_FOUND("4045", HttpStatus.NOT_FOUND, "Not Found: Block Not Found"),
+    MESSAGE_NOT_FOUND("4046", HttpStatus.NOT_FOUND, "Not Found: Message Not Found"),
+    PROMPT_BLOCK_NOT_FOUND("4047", HttpStatus.NOT_FOUND, "Not Found: Prompt Block Not Found"),
     //Forbidden
     UNAUTHORIZED_USER("4030", HttpStatus.FORBIDDEN, "Forbidden: Unauthorized User");
 

--- a/proma/src/main/java/ai/platform/proma/repositroy/MessageRepository.java
+++ b/proma/src/main/java/ai/platform/proma/repositroy/MessageRepository.java
@@ -1,7 +1,12 @@
 package ai.platform.proma.repositroy;
 
+import ai.platform.proma.domain.ChatRoom;
 import ai.platform.proma.domain.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    List<Message> findByChatRoom(ChatRoom chatRoom);
 }

--- a/proma/src/main/java/ai/platform/proma/repositroy/PromptBlockRepository.java
+++ b/proma/src/main/java/ai/platform/proma/repositroy/PromptBlockRepository.java
@@ -1,13 +1,17 @@
 package ai.platform.proma.repositroy;
 
+import ai.platform.proma.domain.Block;
 import ai.platform.proma.domain.Prompt;
 import ai.platform.proma.domain.PromptBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PromptBlockRepository extends JpaRepository<PromptBlock, Long> {
     List<PromptBlock> findByPrompt(Prompt prompt);
+
+    Optional<PromptBlock> findByPromptAndBlock(Prompt prompt, Block block);
 }

--- a/proma/src/main/java/ai/platform/proma/service/ChatRoomService.java
+++ b/proma/src/main/java/ai/platform/proma/service/ChatRoomService.java
@@ -46,4 +46,26 @@ public class ChatRoomService {
         return response;
     }
 
+    public boolean updatePromptBlock(List<ListPromptAtom> listPromptAtoms, Long promptId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        Prompt prompt = promptRepository.findByIdAndUser(promptId, user)
+                .orElseThrow(() -> new ApiException(ErrorDefine.PROMPT_NOT_FOUND));
+
+        List<PromptBlock> promptBlock = promptBlockRepository.findByPrompt(prompt);
+        promptBlockRepository.deleteAll(promptBlock);
+
+        List<Block> blocks = blockRepository.findAllById(listPromptAtoms.stream()
+                .map(ListPromptAtom::getBlockId)
+                .collect(Collectors.toList()));
+
+        List<PromptBlock> savePromptBlocks = blocks.stream()
+                .map(block -> ListPromptAtom.toEntity(prompt, block))
+                .toList();
+
+        promptBlockRepository.saveAll(savePromptBlocks);
+
+        return true;
+    }
 }

--- a/proma/src/main/java/ai/platform/proma/service/ChatRoomService.java
+++ b/proma/src/main/java/ai/platform/proma/service/ChatRoomService.java
@@ -1,0 +1,49 @@
+package ai.platform.proma.service;
+
+import ai.platform.proma.domain.*;
+import ai.platform.proma.dto.request.ListPromptAtom;
+import ai.platform.proma.dto.response.MessageListResponseDto;
+import ai.platform.proma.exception.ApiException;
+import ai.platform.proma.exception.ErrorDefine;
+import ai.platform.proma.repositroy.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+    private final PromptRepository promptRepository;
+    private final BlockRepository blockRepository;
+    private final PromptBlockRepository promptBlockRepository;
+
+    public Map<String, List<MessageListResponseDto>> enterChatRoom(Long chatRoomId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorDefine.USER_NOT_FOUND));
+
+        ChatRoom chatRoom = chatRoomRepository.findByIdAndUser(chatRoomId, user)
+                .orElseThrow(() -> new ApiException(ErrorDefine.CHAT_ROOM_NOT_FOUND));
+
+        List<Message> messages = messageRepository.findByChatRoom(chatRoom);
+        if (messages.isEmpty()) {
+            throw new ApiException(ErrorDefine.MESSAGE_NOT_FOUND);
+        }
+        Map<String, List<MessageListResponseDto>> response = new HashMap<>();
+
+        response.put("selectChatting", messages.stream()
+                .map(message -> MessageListResponseDto.of(message, message.getChatRoom()))
+                .collect(Collectors.toList()));
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- Resolves : #21 
 
## 작업 사항
해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.
- 채팅을 한 히스토리들을 정렬해주고 api이다. 기본적으로 오랜된 메세지를 먼저 보내준다.
- 채팅사이드에서 수정들어가서 블럭 수정하기를 했을 때 블럭에 대한 상세한 수정이 가능하게 해주는 api

