### PR TITLE
feat: 로그인 안한 사용자의 게시글 리스트 조회 기능 추가

### DIFF
--- a/proma/src/main/java/ai/platform/proma/controller/PostController.java
+++ b/proma/src/main/java/ai/platform/proma/controller/PostController.java
@@ -70,6 +70,26 @@ public class PostController {
         return new ResponseDto<>(response);
     }
 
+    @GetMapping("/community-preview")
+    public ResponseDto<Map<String, Object>> getPostsPreview(
+            @Valid @RequestParam(value = "search", required = false) String searchKeyword,
+            @Valid @RequestParam(value = "category", required = false) String category,
+            @Valid @RequestParam(value = "latest", defaultValue = "desc") String latestOrder,
+            @Valid @RequestParam(value = "like", defaultValue = "desc") String likeOrder,
+            @Valid @RequestParam(value = "page", defaultValue = "0") int page,
+            @Valid @RequestParam(value = "size", defaultValue = "9") int size
+    ) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PostResponseDto> postResponseDtos = postService.getPostsPreview(searchKeyword, category, pageable, likeOrder, latestOrder);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("selectPrompt", postResponseDtos.getContent());
+        response.put("pageInfo", new PageInfo(postResponseDtos));
+
+        return new ResponseDto<>(response);
+    }
+
     @PostMapping("/community/scrap/{postId}")
     public ResponseDto<Boolean> promptScrapByPostId(
             @Valid @PathVariable("postId") Long postId, // JWT사용시 수정 필요

--- a/proma/src/main/java/ai/platform/proma/repositroy/LikeRepository.java
+++ b/proma/src/main/java/ai/platform/proma/repositroy/LikeRepository.java
@@ -17,4 +17,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Query("SELECT l.post.id FROM Like l WHERE l.user.id = :userId")
     List<Long> findPostIdsByUserId(@Param("userId") Long userId);
 
+    boolean existsByPost(Post post); // 로그인 안한 사용자
+
 }


### PR DESCRIPTION
## 관련 이슈
- Resolves : #14 
 
## 작업 사항
-  로그인 안한 사용자의 게시글 리스트 조회 api 기능 추가

