### PR TITLE
Fix: 공유와 프롬포트 정렬 과정 생략 

### DIFF
--- a/proma/src/main/java/ai/platform/proma/domain/Prompt.java
+++ b/proma/src/main/java/ai/platform/proma/domain/Prompt.java
@@ -82,7 +82,7 @@ public class Prompt {
                 .promptPreview(prompt.getPromptPreview())
                 .promptCategory(prompt.getPromptCategory())
                 .emoji(prompt.getEmoji())
-                .isScrap(Scrap.NOTSCRAP)
+                .isScrap(Scrap.SHARED)
                 .user(user)
                 .promptMethods(prompt.getPromptMethods())
                 .build();

--- a/proma/src/main/java/ai/platform/proma/exception/ErrorDefine.java
+++ b/proma/src/main/java/ai/platform/proma/exception/ErrorDefine.java
@@ -26,6 +26,7 @@ public enum ErrorDefine {
 
     //Forbidden
     UNAUTHORIZED_USER("4030", HttpStatus.FORBIDDEN, "Forbidden: Unauthorized User"),
+    BLOCK_NOT_MATCH("4038", HttpStatus.FORBIDDEN, "Forbidden: Block Not Match"),
 
     // 소셜로그인 관련
     LOGIN_ACCESS_DENIED("4031", HttpStatus.FORBIDDEN, "Forbidden: Login Access Denied"),

--- a/proma/src/main/java/ai/platform/proma/repositroy/BlockRepository.java
+++ b/proma/src/main/java/ai/platform/proma/repositroy/BlockRepository.java
@@ -19,4 +19,5 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
     Optional<Block> findByBlockValueAndBlockDescriptionAndBlockCategoryAndUserId(String title, String blockDescription, BlockCategory blockCategory, Long userId);
 
+    Optional<Block> findByIdAndPromptMethods(Long id, PromptMethods promptMethods);
 }

--- a/proma/src/main/java/ai/platform/proma/service/PostService.java
+++ b/proma/src/main/java/ai/platform/proma/service/PostService.java
@@ -63,12 +63,14 @@ public class PostService {
         Prompt prompt = promptRepository.findById(promptId)
                 .orElseThrow(() -> new ApiException(ErrorDefine.PROMPT_NOT_FOUND));
 
-        promptRepository.save(Prompt.distributePrompt(prompt, user));
+
+        Prompt prompt1 = promptRepository.save(Prompt.distributePrompt(prompt, user));
+
         postRepository.save(postDistributeRequestDto.toEntity(prompt, postDistributeRequestDto));
 
         List<PromptBlock> promptBlocks = promptBlockRepository.findByPrompt(prompt);
         List<PromptBlock> newPromptBlocks = promptBlocks.stream()
-                .map(promptBlock -> PromptBlock.scrapPromptBlock(prompt, promptBlock.getBlock()))
+                .map(promptBlock -> PromptBlock.scrapPromptBlock(prompt1, promptBlock.getBlock()))
                 .toList();
         promptBlockRepository.saveAll(newPromptBlocks);
 

--- a/proma/src/main/java/ai/platform/proma/service/PromptMakerService.java
+++ b/proma/src/main/java/ai/platform/proma/service/PromptMakerService.java
@@ -68,9 +68,10 @@ public class PromptMakerService {
         Prompt savePrompt = promptSaveRequestDto.toEntity(user, promptMethods, promptSaveRequestDto);
         promptRepository.save(savePrompt);
 
-        List<Block> blocks = blockRepository.findAllById(promptSaveRequestDto.getListPromptAtom().stream()
-                .map(ListPromptAtom::getBlockId)
-                .collect(Collectors.toList()));
+        List<Block> blocks = promptSaveRequestDto.getListPromptAtom().stream()
+                .map(listPromptAtom -> blockRepository.findByIdAndPromptMethods(listPromptAtom.getBlockId(), promptMethods)
+                        .orElseThrow(() -> new ApiException(ErrorDefine.BLOCK_NOT_FOUND)))
+                .toList();
 
         List<PromptBlock> savePromptBlocks = blocks.stream()
                 .map(block -> ListPromptAtom.toEntity(savePrompt, block))


### PR DESCRIPTION
## 관련 이슈
해결한 문제를 지정하는 Issue Index에 연결해야 합니다.

- Resolves : #18 
 
## 작업 사항
해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.
- 공유과정에서 프롬포트블럭 테이블에 똑같은 블럭이 중복으로 들어가지는 현상 수정
- 프롬포트 리스트를 줄때 shared는 제외하고 전달

## 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
